### PR TITLE
changed line 554 of svm/base.py

### DIFF
--- a/sklearn/svm/base.py
+++ b/sklearn/svm/base.py
@@ -551,7 +551,7 @@ class BaseSVC(six.with_metaclass(ABCMeta, BaseLibSVM, ClassifierMixin)):
                           "the shape of the decision function returned by "
                           "SVC.", ChangedBehaviorWarning)
         if self.decision_function_shape == 'ovr' and len(self.classes_) > 2:
-            return _ovr_decision_function(dec < 0, dec, len(self.classes_))
+            return _ovr_decision_function(dec < 0, -dec, len(self.classes_))
         return dec
 
     def predict(self, X):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Issue #6416

#### What does this implement/fix? Explain your changes.
Changed the sign of dec for the function _ovr_decision_function
from
return _ovr_decision_function(dec < 0, dec, len(self.classes_))
to
return _ovr_decision_function(dec < 0, -dec, len(self.classes_))

Reason: for function _ovr_decision_function, the first argument should be consistent with the second argument, so if we take dec < 0, i.e., set True for negative decision value, the confidence that we feed into _ovr_decision_function needs to be inverted as well.

Hence I proposed the above change. Please kindly refer to the examples in issue #6416, thank you very much. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->

the sign of dec values should be changed to feed into function _ovr_decision_function