### PR TITLE
bug: fix _ovr_decision_function from ovo case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,6 @@ clean: clean-ctags
 
 in: inplace # just a shortcut
 inplace:
-	# to avoid errors in 0.15 upgrade
-	rm -f sklearn/utils/sparsefuncs*.so
-	rm -f sklearn/utils/random*.so
 	$(PYTHON) setup.py build_ext -i
 
 test-code: in

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -95,7 +95,11 @@ Bug fixes
      `#6497 <https://github.com/scikit-learn/scikit-learn/pull/6497>`_
      by `Sebastian Säger`_
 
-
+   - Fixes issue in :ref:`univariate_feature_selection` where score 
+     functions were not accepting multi-label targets.(`#7676
+     <https://github.com/scikit-learn/scikit-learn/pull/7676>`_)
+     by `Mohammed Affan`_
+     
 .. _changes_0_18:
 
 Version 0.18

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -4886,3 +4886,7 @@ David Huard, Dave Morrill, Ed Schofield, Travis Oliphant, Pearu Peterson.
 .. _Narine Kokhlikyan: https://github.com/NarineK
 
 .. _Peng Meng: https://github.com/mpjlu
+
+.. _Dylan Werner-Meier: https://github.com/unautre
+
+.. _Alyssa Batula: https://github.com/abatula

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -19,6 +19,11 @@ New features
 Enhancements
 ............
 
+   - Added ``classes_`` attribute to :class:`model_selection.GridSearchCV`
+     that matches the ``classes_`` attribute of ``best_estimator_``. (`#7661
+     <https://github.com/scikit-learn/scikit-learn/pull/7661>`_) by `Alyssa
+     Batula`_ and `Dylan Werner-Meier`_.
+
    - The ``min_weight_fraction_leaf`` constraint in tree construction is now
      more efficient, taking a fast path to declare a node a leaf if its weight
      is less than 2 * the minimum. Note that the constructed tree will be

--- a/sklearn/covariance/outlier_detection.py
+++ b/sklearn/covariance/outlier_detection.py
@@ -108,10 +108,6 @@ class EllipticEnvelope(ClassifierMixin, OutlierDetectionMixin, MinCovDet):
 
     Attributes
     ----------
-    `contamination` : float, 0. < contamination < 0.5
-      The amount of contamination of the data set, i.e. the proportion of \
-      outliers in the data set.
-
     location_ : array-like, shape (n_features,)
         Estimated robust location
 

--- a/sklearn/feature_selection/tests/test_feature_select.py
+++ b/sklearn/feature_selection/tests/test_feature_select.py
@@ -519,6 +519,21 @@ def test_tied_pvalues():
         assert_not_in(9998, Xt)
 
 
+def test_scorefunc_multilabel():
+    # Test whether k-best and percentiles works with multilabels with chi2.
+
+    X = np.array([[10000, 9999, 0], [100, 9999, 0], [1000, 99, 0]])
+    y = [[1, 1], [0, 1], [1, 0]]
+
+    Xt = SelectKBest(chi2, k=2).fit_transform(X, y)
+    assert_equal(Xt.shape, (3, 2))
+    assert_not_in(0, Xt)
+
+    Xt = SelectPercentile(chi2, percentile=67).fit_transform(X, y)
+    assert_equal(Xt.shape, (3, 2))
+    assert_not_in(0, Xt)
+
+
 def test_tied_scores():
     # Test for stable sorting in k-best with tied scores.
     X_train = np.array([[0, 0, 0], [1, 1, 1]])

--- a/sklearn/feature_selection/univariate_selection.py
+++ b/sklearn/feature_selection/univariate_selection.py
@@ -319,7 +319,7 @@ class _BaseFilter(BaseEstimator, SelectorMixin):
         self : object
             Returns self.
         """
-        X, y = check_X_y(X, y, ['csr', 'csc'])
+        X, y = check_X_y(X, y, ['csr', 'csc'], multi_output=True)
 
         if not callable(self.score_func):
             raise TypeError("The score function should be a callable, %s (%s) "

--- a/sklearn/grid_search.py
+++ b/sklearn/grid_search.py
@@ -387,6 +387,10 @@ class BaseSearchCV(six.with_metaclass(ABCMeta, BaseEstimator,
     def _estimator_type(self):
         return self.estimator._estimator_type
 
+    @property
+    def classes_(self):
+        return self.best_estimator_.classes_
+
     def score(self, X, y=None):
         """Returns the score on the given data, if the estimator has been refit.
 
@@ -688,7 +692,7 @@ class GridSearchCV(BaseSearchCV):
         - An iterable yielding train/test splits.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
-        either binary or multiclass, 
+        either binary or multiclass,
         :class:`sklearn.model_selection.StratifiedKFold` is used. In all
         other cases, :class:`sklearn.model_selection.KFold` is used.
 
@@ -900,7 +904,7 @@ class RandomizedSearchCV(BaseSearchCV):
         - An iterable yielding train/test splits.
 
         For integer/None inputs, if the estimator is a classifier and ``y`` is
-        either binary or multiclass, 
+        either binary or multiclass,
         :class:`sklearn.model_selection.StratifiedKFold` is used. In all
         other cases, :class:`sklearn.model_selection.KFold` is used.
 

--- a/sklearn/mixture/base.py
+++ b/sklearn/mixture/base.py
@@ -385,7 +385,7 @@ class BaseMixture(six.with_metaclass(ABCMeta, DensityMixin, BaseEstimator)):
 
         _, n_features = self.means_.shape
         rng = check_random_state(self.random_state)
-        n_samples_comp = np.round(self.weights_ * n_samples).astype(int)
+        n_samples_comp = rng.multinomial(n_samples, self.weights_)
 
         if self.covariance_type == 'full':
             X = np.vstack([

--- a/sklearn/mixture/tests/test_gaussian_mixture.py
+++ b/sklearn/mixture/tests/test_gaussian_mixture.py
@@ -918,7 +918,7 @@ def test_property():
 
 def test_sample():
     rng = np.random.RandomState(0)
-    rand_data = RandomData(rng, scale=7)
+    rand_data = RandomData(rng, scale=7, n_components=3)
     n_features, n_components = rand_data.n_features, rand_data.n_components
 
     for covar_type in COVARIANCE_TYPE:
@@ -935,8 +935,10 @@ def test_sample():
                              gmm.sample, 0)
 
         # Just to make sure the class samples correctly
-        X_s, y_s = gmm.sample(20000)
-        for k in range(n_features):
+        n_samples = 20000
+        X_s, y_s = gmm.sample(n_samples)
+
+        for k in range(n_components):
             if covar_type == 'full':
                 assert_array_almost_equal(gmm.covariances_[k],
                                           np.cov(X_s[y_s == k].T), decimal=1)
@@ -953,8 +955,16 @@ def test_sample():
                     decimal=1)
 
         means_s = np.array([np.mean(X_s[y_s == k], 0)
-                           for k in range(n_features)])
+                           for k in range(n_components)])
         assert_array_almost_equal(gmm.means_, means_s, decimal=1)
+
+        # Check shapes of sampled data, see
+        # https://github.com/scikit-learn/scikit-learn/issues/7701
+        assert_equal(X_s.shape, (n_samples, n_features))
+
+        for sample_size in range(1, 100):
+            X_s, _ = gmm.sample(sample_size)
+            assert_equal(X_s.shape, (sample_size, n_features))
 
 
 @ignore_warnings(category=ConvergenceWarning)

--- a/sklearn/model_selection/tests/test_validation.py
+++ b/sklearn/model_selection/tests/test_validation.py
@@ -717,13 +717,15 @@ def test_learning_curve_with_boolean_indices():
 
 
 def test_learning_curve_with_shuffle():
-    """Following test case was designed this way to verify the code
-    changes made in pull request: #7506."""
+    # Following test case was designed this way to verify the code
+    # changes made in pull request: #7506.
     X = np.array([[1, 2], [3, 4], [5, 6], [7, 8], [11, 12], [13, 14], [15, 16],
                  [17, 18], [19, 20], [7, 8], [9, 10], [11, 12], [13, 14],
                  [15, 16], [17, 18]])
     y = np.array([1, 1, 1, 2, 3, 4, 1, 1, 2, 3, 4, 1, 2, 3, 4])
     groups = np.array([1, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 4, 4, 4, 4])
+    # Splits on these groups fail without shuffle as the first iteration
+    # of the learning curve doesn't contain label 4 in the training set.
     estimator = PassiveAggressiveClassifier(shuffle=False)
 
     cv = GroupKFold(n_splits=2)

--- a/sklearn/neural_network/multilayer_perceptron.py
+++ b/sklearn/neural_network/multilayer_perceptron.py
@@ -562,7 +562,7 @@ class BaseMultilayerPerceptron(six.with_metaclass(ABCMeta, BaseEstimator)):
                                   'converged yet.'
                                   % (), ConvergenceWarning)
         except KeyboardInterrupt:
-            pass
+            warnings.warn("Training interrupted by user.")
 
         if early_stopping:
             # restore best weights

--- a/sklearn/tests/test_grid_search.py
+++ b/sklearn/tests/test_grid_search.py
@@ -42,6 +42,7 @@ from sklearn.neighbors import KernelDensity
 from sklearn.metrics import f1_score
 from sklearn.metrics import make_scorer
 from sklearn.metrics import roc_auc_score
+from sklearn.linear_model import Ridge
 
 from sklearn.exceptions import ChangedBehaviorWarning
 from sklearn.exceptions import FitFailedWarning
@@ -785,3 +786,20 @@ def test_parameters_sampler_replacement():
     sampler = ParameterSampler(params_distribution, n_iter=7)
     samples = list(sampler)
     assert_equal(len(samples), 7)
+
+
+def test_classes__property():
+    # Test that classes_ property matches best_esimator_.classes_
+    X = np.arange(100).reshape(10, 10)
+    y = np.array([0] * 5 + [1] * 5)
+    Cs = [.1, 1, 10]
+
+    grid_search = GridSearchCV(LinearSVC(random_state=0), {'C': Cs})
+    grid_search.fit(X, y)
+    assert_array_equal(grid_search.best_estimator_.classes_,
+                       grid_search.classes_)
+
+    # Test that regressors do not have a classes_ attribute
+    grid_search = GridSearchCV(Ridge(), {'alpha': [1.0, 2.0]})
+    grid_search.fit(X, y)
+    assert_false(hasattr(grid_search, 'classes_'))


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/master/CONTRIBUTING.md#Contributing-Pull-Requests
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->

Issue #6416

#### What does this implement/fix? Explain your changes.

Changed the sign of dec for the function ovr_decision_function
from
`return _ovr_decision_function(dec < 0, dec, len(self.classes))`
to
`return ovr_decision_function(dec < 0, -dec, len(self.classes))`

Reason: for function _ovr_decision_function, the first argument should be consistent with the second argument, so if we take dec < 0, i.e., set True for negative decision value, the confidence that we feed into _ovr_decision_function needs to be inverted as well.

Hence I proposed the above change. Please kindly refer to the examples in issue #6416, thank you very much. 

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
